### PR TITLE
FEAT: Add prowler-v2 integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,26 @@
 FROM kalilinux/kali-rolling
 
-ENV HOSTNAME=${DOCKER_HOSTNAME:-auditbox}
-ENV TZ=Europe/Bucharest
-
 COPY ./arsenal/xtra-tools.txt /tmp/
 
 # If you want to install other tools, add them in the tools/xtra-tools.txt file
 RUN useradd -ms /bin/bash auditor													&& \
+		echo "auditbox" > /etc/hostname												&& \
 		apt update																						&& \
-		apt upgrade -y																				&& \
 		apt autoremove																				&& \
 		apt install -y $(cat /tmp/xtra-tools.txt | xargs)			&& \
 		pip install pipenv
 
+# 		apt upgrade -y																				&& \
+
 WORKDIR /home/auditor
 
 USER auditor
+
+ENV HOSTNAME=auditbox
+ENV TZ=Europe/Bucharest
+
+ENV HOME=/home/auditor
+ENV PATH="$HOME/.local/bin:$PATH"
 
 COPY --chown=auditor:auditor ./arsenal/python-tools.txt /tmp/
 COPY --chown=auditor:auditor ./arsenal/build-tools.sh /tmp/

--- a/Makefile
+++ b/Makefile
@@ -4,46 +4,48 @@ default: help
 
 all: ## 🚀 Build dependencies and start security audits 🔒🔍
 	@make clean
-	@time make build-n-run
-	@echo \n\n ==> 🚀 Starting security audits 🔒🔍
-	@time make audit
+	@make build-n-run
+	@echo "\n\n==> 🚀 Starting security audits 🔒🔍"
+	@make audit
 
 audit: ## 🛡️ Audit AWS account with all the tools (Prowler, ScoutSuite, CloudSplaining, PMapper)
-	@time make prowler
-	@time make scoutsuite
-	@time make cloudsplaining
-	@time make pmapper
+	@make prowler
+	@make scoutsuite
+	@make cloudsplaining
+	@make pmapper
 	@make gather-results
 
 install-deps:	## ❌ (out of scope) Install git and docker if you want to continue
 	@echo "git & docker installation are out of scope. You should install them if you want to continue"
 
 build-n-run: ## 🛠️ 🐳 Build and start the containers
-	@echo \n\n==> 🛠️ Building auditBox container..."
-	@time make build-auditbox
-	@echo \n\n==> 🛠️ Building pmapper container..."
-	@time make build-pmapper
+	@echo "\n\n==> 🛠️ Building auditBox container..."
+	@make build-auditbox
+	@echo "\n\n==> 🛠️ Building pmapper container..."
+	@make build-pmapper
 	@make run
 
 ## 🛠️ Build auditbox container using Kali Linux rolling as base image
 build-auditbox:
 	@docker pull kalilinux/kali-rolling
 	@mkdir -p ./auditbox-results ./logs
-	@time docker build --no-cache --progress=plain -t kali:auditing . 2>&1 | tee ./logs/dockerbuild-auditbox.log
+	@docker build --no-cache --progress=plain -t kali:auditing . 2>&1 | tee ./logs/dockerbuild-auditbox.log
 
 
 ## 🛠️ Pull latest code from GitHub and build pmapper container
 build-pmapper:
+	@rm -rf arsenal/pmapper
 	@git submodule add --force --name pmapper -- https://github.com/nccgroup/PMapper arsenal/pmapper
 	@pushd arsenal/pmapper && \
-		time docker build --no-cache --progress=plain -t pmapper . 2>&1 | tee ../../logs/dockerbuild-pmapper.log
+		docker build --no-cache --progress=plain -t pmapper . 2>&1 | tee ../../logs/dockerbuild-pmapper.log
 
 ## 🛠️ Pull latest code from GitHub and build pmapper container
 build-cloudsploit:
+	@rm -rf arsenal/cloudsploit
 	@git submodule add --force --name cloudsploit -- https://github.com/aquasecurity/cloudsploit arsenal/cloudsploit
 	@pushd arsenal/cloudsploit 														&& \
 		patch Dockerfile < ../cloudsploitDockerfile.patch 		&& \
-		time docker build --no-cache --progress=plain -t cloudsploit . 2>&1 | tee ../../logs/dockerbuild-cloudsploit.log
+		docker build --no-cache --progress=plain -t cloudsploit . 2>&1 | tee ../../logs/dockerbuild-cloudsploit.log
 
 ## 🐳 Start auditbox & pmapper containers
 run:
@@ -66,13 +68,17 @@ prowler: ## 🔍 Audit AWS account with Prowler
 	@echo "\n\n==> 🔍 Prowler scan has started."
 	@docker exec -it auditbox bash -c "pipenv run prowler aws --no-banner --output-modes {csv,json,json-asff,html} --compliance cis_1.5_aws"
 
+prowler-v2: ## 🔍 Audit AWS account with Prowler v2
+	@echo "\n\n==> 🔍 Prowler v2 scan has started."
+	@docker exec -it auditbox bash -c "~/tools/prowler/prowler -g cislevel1 -M csv,json-assf,html"
+
 scoutsuite: ## 🔍 Audit AWS account with ScoutSuite
 	@echo "\n\n==> 🔍 ScoutSuite scan has started."
 	@docker exec -it auditbox bash -c "pipenv run scout aws --report-name scoutsuite --result-format json"
 
 cloudsploit: ## 🔍 Audit AWS account with CloudSploit
-	@echo "\n\n==> 🔍 CloudSploit scan has started."
-	@time docker exec -it cloudsploit cloudsploit-scan --compliance=cis1 --ignore-ok --collection=cloudsploit-collection.json --console=table --csv=cloudsploit-findings.csv --json cloudsploit-findings.json
+	@echo "\n\n ==> 🔍 CloudSploit scan has started."
+	@docker exec -it cloudsploit cloudsploit-scan --compliance=cis1 --ignore-ok --collection=cloudsploit-collection.json --console=table --csv=cloudsploit-findings.csv --json cloudsploit-findings.json
 
 gather-results: ## 💾 Copy all scan results locally in auditbox-results directory
 	@rm -rf auditbox-results && mkdir auditbox-results

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ gather-results: ## 💾 Copy all scan results locally in auditbox-results direct
 	@mkdir -p ./auditbox-results/{pmapper,cloudsploit}/ && \
 		docker exec pmapper /bin/sh -c 'tar -cf - /*.png' | tar xvf - --directory=./auditbox-results/pmapper/								|| true
 	@docker exec cloudsploit /bin/sh -c 'tar -cf - /cloudsploit-*' | tar xvf - --directory=./auditbox-results/cloudsploit/	|| true
+	@docker cp auditbox:/home/auditor/tools/prowler/output ./auditbox-results/prowler-v2																		|| true
 
 clean: ## 🧹 Delete scan results, stop and delete containers
 	@echo "Cleaning has started..."

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ build-auditbox:
 	@mkdir -p ./auditbox-results ./logs
 	@docker build --no-cache --progress=plain -t kali:auditing . 2>&1 | tee ./logs/dockerbuild-auditbox.log
 
-
 ## 🛠️ Pull latest code from GitHub and build pmapper container
 build-pmapper:
 	@rm -rf arsenal/pmapper
@@ -47,11 +46,20 @@ build-cloudsploit:
 		patch Dockerfile < ../cloudsploitDockerfile.patch 		&& \
 		docker build --no-cache --progress=plain -t cloudsploit . 2>&1 | tee ../../logs/dockerbuild-cloudsploit.log
 
-## 🐳 Start auditbox & pmapper containers
-run:
+run: ## 🐳 Start auditbox, cloudsploit & pmapper containers
+	@make run-auditbox
+	@make run-cloudsploit
+	@make run-pmapper
+
+# Alternatively you can start each container
+run-auditbox:
 	@docker run --env-file=./env.list --rm -d --name auditbox kali:auditing
-	@docker run --env-file=./env.list --rm -d --name pmapper pmapper bash -c "sleep infinity & wait"
+
+run-cloudsploit:
 	@docker run --env-file=./env.list --rm -d --entrypoint sh --name cloudsploit cloudsploit -c "sleep infinity & wait"
+
+run-pmapper:
+	@docker run --env-file=./env.list --rm -d --name pmapper pmapper bash -c "sleep infinity & wait"
 
 cloudsplaining: ## 🔍 Audit AWS account with CloudSplaining
 	@echo "\n\n==> 🔍 CloudSplaining scan has started."

--- a/arsenal/build-tools.sh
+++ b/arsenal/build-tools.sh
@@ -6,13 +6,21 @@ echo "Installing tools..."
 
 # This function will install all Python packages defined in the python-tools.txt file
 function pythonTools() {
+	pip install awscli		# Install awscli system wide instead just inside pipenv
 	pipenv install --ignore-pipfile --requirements /tmp/python-tools.txt
 	echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 }
 
+function prowlerV2(){
+	git clone https://github.com/prowler-cloud/prowler
+	cd ./prowler
+	git checkout origin/prowler-2 2>/dev/null		# Ignoring 'detached HEAD' state error message
+}
+
 # Nothing here yet
 function customTools() {
-mkdir -p ~/tools && cd ~/tools
+	mkdir -p ~/tools && cd ~/tools
+	prowlerV2
 }
 
 #------#

--- a/arsenal/build-tools.sh
+++ b/arsenal/build-tools.sh
@@ -2,7 +2,7 @@
 
 export USER=auditor
 
-echo "Installing tools..."
+echo -e "\n\n==> Installing tools..."
 
 # This function will install all Python packages defined in the python-tools.txt file
 function pythonTools() {

--- a/arsenal/build-tools.sh
+++ b/arsenal/build-tools.sh
@@ -6,9 +6,9 @@ echo -e "\n\n==> Installing tools..."
 
 # This function will install all Python packages defined in the python-tools.txt file
 function pythonTools() {
-	pip install awscli		# Install awscli system wide instead just inside pipenv
+	pip install awscli		# Install awscli system wide instead inside pipenv (python-tools.txt)
 	pipenv install --ignore-pipfile --requirements /tmp/python-tools.txt
-	echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+	pipenv lock --clear		# Clear pipenv cache to reduce container image size
 }
 
 function prowlerV2(){

--- a/arsenal/python-tools.txt
+++ b/arsenal/python-tools.txt
@@ -1,4 +1,3 @@
-awscli
 detect-secrets
 cloudsplaining
 prowler-cloud


### PR DESCRIPTION
- - ADD: prowler v2 - FIX: cloudmapper built - CHG: Remove `time` cmd - CHG: Install awscli system wide instead
- CHG: copy prowler-v2 scan results
- CHG: Add option to start each container separately
- FIX: `~/.local/bin` not in `$PATH`
